### PR TITLE
Now NF Template ID is assigned by the datastore + refactoring v2 APIs

### DIFF
--- a/datastore/API.py
+++ b/datastore/API.py
@@ -61,6 +61,9 @@ def addVNFTemplateV2(template, capability, image_upload_status):
 	# Return the generated NF ID
 	return vnf_id
 
+def updateVNFTemplate(vnf_id, template, capability):
+	VNF.objects.filter(vnf_id=str(vnf_id)).update(template=base64.b64encode(template), capability=capability)
+
 def addNF_FGraphs(nf_fgraphs_id, nf_fgraphs_template):
 	if nf_fgraphs_id != json.loads(nf_fgraphs_template)['forwarding-graph']['id']:
 		return False

--- a/datastore/API.py
+++ b/datastore/API.py
@@ -10,12 +10,13 @@ def getVNFTemplate(vnf_id=None):
 	else:
 		vnf = VNF.objects.all()
 		# Filter out templates with uncompleted images
-		vnf = vnf.filter(image_upload_complete=True)
+		vnf = vnf.exclude(image_upload_status=VNF.IN_PROGRESS)
 		vnfList = []
 		for foundVNF in vnf:
 			newVNF = {}
 			newVNF['id'] = foundVNF.vnf_id
 			newVNF['template'] = json.loads(base64.b64decode(foundVNF.template))
+			newVNF['image-upload-status'] = foundVNF.image_upload_status
 			vnfList.append(newVNF)
 		return {'list':vnfList}
 
@@ -26,12 +27,13 @@ def getVNFTemplate(vnf_id=None):
 def getTemplatesFromCapability(vnfCapability):
 	vnf = VNF.objects.filter(capability=str(vnfCapability))
 	# Filter out templates with uncompleted images
-	vnf = vnf.filter(image_upload_complete=True)
+	vnf = vnf.exclude(image_upload_status=VNF.IN_PROGRESS)
 	vnfList = []
 	for foundVNF in vnf:
 		newVNF = {}
 		newVNF['id'] = foundVNF.vnf_id
 		newVNF['template'] = json.loads(base64.b64decode(foundVNF.template))
+		newVNF['image-upload-status'] = foundVNF.image_upload_status
 		vnfList.append(newVNF)
 	return {'list': vnfList}
 
@@ -46,7 +48,7 @@ def addVNFTemplate(vnf_id, template, capability):
 	vnf = VNF(vnf_id = str(vnf_id), template = base64.b64encode(template), capability=capability)
 	vnf.save()
 
-def addVNFTemplateV2(template, capability, image_upload_complete):
+def addVNFTemplateV2(template, capability, image_upload_status):
 	# Generate 6 chars alphanumeric nonce and verify its uniqueness
 	while True:
 		vnf_id = ''.join(random.SystemRandom().choice(string.ascii_uppercase + string.digits) for _ in range(6))
@@ -54,7 +56,7 @@ def addVNFTemplateV2(template, capability, image_upload_complete):
 		if len(vnf) == 0:
 			break
 	# Store the template
-	vnf = VNF(vnf_id = vnf_id, template = base64.b64encode(template), capability=capability, image_upload_complete=image_upload_complete)
+	vnf = VNF(vnf_id = vnf_id, template = base64.b64encode(template), capability=capability, image_upload_status=image_upload_status)
 	vnf.save()
 	# Return the generated NF ID
 	return vnf_id

--- a/datastore/imageRepository/LocalRepository.py
+++ b/datastore/imageRepository/LocalRepository.py
@@ -1,21 +1,26 @@
 import os
+import glob
 from wsgiref.util import FileWrapper
 
+
 class LocalRepository(object):
-	
-	def __init__(self, imagesDir):
-		self.imagesDir = imagesDir
+    def __init__(self, imagesDir):
+        self.imagesDir = imagesDir
 
-	def storeImage(self, vnf_id, imageFile):
-		if not os.path.exists(self.imagesDir):
-			os.makedirs(self.imagesDir)
-		with open(self.imagesDir + str(vnf_id), 'wb')as f:
-                	for chunk in imageFile.chunks():
-                        	f.write(chunk)
+    def storeImage(self, vnf_id, imageFile):
+        ext = os.path.splitext(imageFile.name)[1]
+        if not os.path.exists(self.imagesDir):
+            os.makedirs(self.imagesDir)
+        with open(os.path.join(self.imagesDir, str(vnf_id) + ext), 'wb') as f:
+            for chunk in imageFile.chunks():
+                f.write(chunk)
 
-	def getImage(self, vnf_id):
-		filename = self.imagesDir + str(vnf_id)
+    def getImage(self, vnf_id):
+        filename = glob.glob(os.path.join(self.imagesDir, str(vnf_id) + '.*'))[0]
+        wrapper = FileWrapper(file(filename))
+        fileLen = os.path.getsize(filename)
+        return (wrapper, fileLen)
 
-		wrapper = FileWrapper(file(filename))
-		fileLen = os.path.getsize(filename)
-		return (wrapper, fileLen)
+    def deleteImage(self, vnf_id):
+        filename = glob.glob(os.path.join(self.imagesDir, str(vnf_id) + '.*'))[0]
+        os.remove(filename)

--- a/datastore/management/commands/delete_expired_uploads.py
+++ b/datastore/management/commands/delete_expired_uploads.py
@@ -7,14 +7,15 @@ from django.utils.translation import ugettext as _
 from chunked_upload.settings import EXPIRATION_DELTA
 from chunked_upload.constants import UPLOADING, COMPLETE
 from datastore.models import MyChunkedUpload
+from datastore.models import VNF
 
 prompt_msg = _(u'Do you want to delete {obj}?')
 
 
 class Command(BaseCommand):
 
-    # Has to be a ChunkedUpload subclass
     model = MyChunkedUpload
+    vnf = VNF
 
     help = 'Deletes chunked uploads that have already expired.'
 
@@ -42,8 +43,13 @@ class Command(BaseCommand):
                 if answer == 'n':
                     continue
 
+            # Deleting NF Template associated to uncompleted NF Image upload
+            uncomplete_vnf = self.vnf.objects.filter(vnf_id=chunked_upload.vnf_id)
+            if len(uncomplete_vnf) != 0:
+                uncomplete_vnf[0].delete()
+
             count[chunked_upload.status] += 1
-            # Deleting objects individually to call delete method explicitly
+            # Deleting uncompleted NF Image upload both from DB and from disk
             chunked_upload.delete()
 
         print('%i complete uploads were deleted.' % count[COMPLETE])

--- a/datastore/management/commands/delete_expired_uploads.py
+++ b/datastore/management/commands/delete_expired_uploads.py
@@ -46,7 +46,8 @@ class Command(BaseCommand):
             # Deleting NF Template associated to uncompleted NF Image upload
             uncomplete_vnf = self.vnf.objects.filter(vnf_id=chunked_upload.vnf_id)
             if len(uncomplete_vnf) != 0:
-                uncomplete_vnf[0].delete()
+                if uncomplete_vnf[0].image_upload_status == VNF.IN_PROGRESS:
+                    uncomplete_vnf[0].delete()
 
             count[chunked_upload.status] += 1
             # Deleting uncompleted NF Image upload both from DB and from disk

--- a/datastore/models.py
+++ b/datastore/models.py
@@ -7,10 +7,22 @@ class MyChunkedUpload(ChunkedUpload):
 MyChunkedUpload._meta.get_field('user').null = True
 
 class VNF(models.Model):
+	IN_PROGRESS = 'IP'
+	COMPLETED = 'CO'
+	REMOTE = 'RE'
+	IMAGE_UPLOAD_STATUS = (
+		(IN_PROGRESS, 'In progress'),
+		(COMPLETED, 'Completed'),
+		(REMOTE, 'Remote')
+	)
 	vnf_id = models.CharField(primary_key=True, unique=True,max_length=100)
 	template = models.CharField(max_length=60000,blank=False)
 	capability = models.CharField(max_length=600)
-	image_upload_complete = models.BooleanField(default=True)
+	image_upload_status = models.CharField(
+		max_length=2,
+		choices=IMAGE_UPLOAD_STATUS,
+		default=COMPLETED
+	)
 
 class NF_FGraphs(models.Model):
 	nf_fgraphs_id = models.CharField(primary_key=True, unique=True,max_length=100)

--- a/datastore/models.py
+++ b/datastore/models.py
@@ -2,7 +2,7 @@ from django.db import models
 from chunked_upload.models import ChunkedUpload
 
 class MyChunkedUpload(ChunkedUpload):
-    pass
+	vnf_id = models.CharField(unique=True, max_length=100)
 # Override the default ChunkedUpload to make the `user` field nullable
 MyChunkedUpload._meta.get_field('user').null = True
 
@@ -10,6 +10,7 @@ class VNF(models.Model):
 	vnf_id = models.CharField(primary_key=True, unique=True,max_length=100)
 	template = models.CharField(max_length=60000,blank=False)
 	capability = models.CharField(max_length=600)
+	image_upload_complete = models.BooleanField(default=True)
 
 class NF_FGraphs(models.Model):
 	nf_fgraphs_id = models.CharField(primary_key=True, unique=True,max_length=100)

--- a/datastore/urlsV2.py
+++ b/datastore/urlsV2.py
@@ -2,11 +2,11 @@ from django.conf.urls import url
 from datastore import views
 
 urlpatterns = [
-        url(r'^/nf_template/$', views.VNFTemplateAll.as_view(), name='VNF Template'),
-        url(r'^/nf_template/(?P<vnf_id>[^/]+)/$', views.VNFTemplate.as_view(), name='VNF List'),
+        url(r'^/nf_template/$', views.VNFTemplateAllV2.as_view(), name='VNF Template'),
+        url(r'^/nf_template/(?P<vnf_id>[^/]+)/$', views.VNFTemplateV2.as_view(), name='VNF List'),
         url(r'^/nf_image/chunked_upload/?$', views.MyChunkedUploadView.as_view(), name='api_chunked_upload'),
         url(r'^/nf_image/chunked_upload_complete/?$', views.MyChunkedUploadCompleteView.as_view(), name='api_chunked_upload_complete'),
-        url(r'^/nf_image/(?P<vnf_id>[^/]+)/$', views.VNFImage.as_view(), name='VNF image'),
+        url(r'^/nf_image/(?P<vnf_id>[^/]+)/$', views.VNFImageV2.as_view(), name='VNF image'),
         url(r'^/nffg/(?P<nf_fgraphs_id>[^/]+)/$', views.NFFGraphs.as_view(), name='NFFGraphs data'),
         url(r'^/nffg/$', views.NF_FGraphsAll.as_view(), name='nf_fgraphs list'),
         url(r'^/nffg_digest/$', views.NF_FGraphsAll_graphs_names.as_view(), name='nf_fgraphs list name'),

--- a/datastore/views.py
+++ b/datastore/views.py
@@ -165,7 +165,7 @@ class VNFImage(APIView):
         try:
             state = VNF.objects.get(vnf_id=str(vnf_id)).image_upload_status
             if state == VNF.COMPLETED:
-                os.remove(os.path.join(imagesDir, vnf_id))
+                imageRepo.deleteImage(vnf_id)
             return HttpResponse(status=200)
         except:
             return HttpResponse(status=400)

--- a/datastore/views.py
+++ b/datastore/views.py
@@ -119,7 +119,17 @@ class VNFTemplateV2(VNFTemplate):
         """
         Update an existing VNF template
         """
-        return super(VNFTemplateV2, self).put(request, vnf_id)
+        if request.META['CONTENT_TYPE'] != 'application/json':
+            return HttpResponse(status=415)
+        try:
+            if 'functional-capability' not in request.data.keys():
+                return HttpResponse("Missing functional-capability field", status=400)
+            capability = request.data['functional-capability']
+            template = json.dumps(request.data)
+        except:
+            return HttpResponse(status=400)
+        API.updateVNFTemplate(vnf_id, template, capability)
+        return HttpResponse(status=200)
 
 
 class VNFImage(APIView):

--- a/datastore/views.py
+++ b/datastore/views.py
@@ -18,236 +18,307 @@ from xml.dom import minidom
 import json
 from datastore.imageRepository.LocalRepository import LocalRepository
 from chunked_upload.views import ChunkedUploadView, ChunkedUploadCompleteView
-from .models import MyChunkedUpload
+from .models import MyChunkedUpload, VNF
 from django.views.decorators.csrf import csrf_exempt
 from django.utils.decorators import method_decorator
 
 parser = SafeConfigParser()
 parser.read(os.environ["DATASTORE_CONFIG_FILE"])
-logging.basicConfig(filename=parser.get('logging','filename'),format='%(asctime)s %(levelname)s:%(message)s', level=parser.get('logging','level'))
+logging.basicConfig(filename=parser.get('logging', 'filename'), format='%(asctime)s %(levelname)s:%(message)s',
+                    level=parser.get('logging', 'level'))
 repository = parser.get('repository', 'repository')
 if repository == "LOCAL_FILES":
-	imagesDir = parser.get('General', 'IMAGE_DIR')
-	imageRepo = LocalRepository(imagesDir)
+    imagesDir = parser.get('General', 'IMAGE_DIR')
+    imageRepo = LocalRepository(imagesDir)
+
 
 class VNFTemplateAll(APIView):
-	"""
-	"""
-	
-	def get(self, request):
-		"""
-		Get the all VNF with the respectively template
-		"""
-		template = API.getVNFTemplate()
-		if template is None:
-			return HttpResponse(status=404)
-		return Response(data=template)
+    """
+    """
 
-	
+    def get(self, request):
+        """
+        Get the all VNF with the respectively template
+        """
+        template = API.getVNFTemplate()
+        if template is None:
+            return HttpResponse(status=404)
+        return Response(data=template)
+
+
+class VNFTemplateAllV2(VNFTemplateAll):
+    """
+    """
+
+    def put(self, request):
+        """
+        Create a new VNF template. The 'vnf_id' assigned by the datastore is contained in the response.
+        """
+        if request.META['CONTENT_TYPE'] != 'application/json':
+            return HttpResponse(status=415)
+        try:
+            if 'functional-capability' not in request.data.keys():
+                return HttpResponse("Missing functional-capability field", status=400)
+            capability = request.data['functional-capability']
+            template = json.dumps(request.data)
+        except:
+            return HttpResponse(status=400)
+
+        image_upload_complete = False
+        # if 'uri-type' in request.data.keys():
+        #     if request.data['uri-type'] == 'remote-file':
+        #         image_upload_complete = True
+
+        vnf_id = API.addVNFTemplateV2(template, capability, image_upload_complete)
+        return HttpResponse(vnf_id, status=200)
+
+
 class VNFTemplate(APIView):
-	"""
-	"""
-	def get(self, request, vnf_id):
-		"""
-		Get the VNF template of a VNF
-		"""
-		template = API.getVNFTemplate(vnf_id)
-		if template is None:
-			return HttpResponse(status=404)
-		return Response(data=template)
+    """
+    """
 
-	def put(self, request, vnf_id):
-		"""
-		Update or create a new VNF template
-		"""
-		if request.META['CONTENT_TYPE'] != 'application/json':
-			return HttpResponse(status=415)
-		try:
-			if 'functional-capability' not in request.data.keys():
-				return HttpResponse("Missing functional-capability field", status=400)
-			capability = request.data['functional-capability']
-			template = json.dumps(request.data)
-		except:
-			return HttpResponse(status=400)	
-		API.addVNFTemplate(vnf_id, template, capability)
-		return HttpResponse(status=200)
+    def get(self, request, vnf_id):
+        """
+        Get the VNF template of a VNF
+        """
+        template = API.getVNFTemplate(vnf_id)
+        if template is None:
+            return HttpResponse(status=404)
+        return Response(data=template)
 
-	def delete(self, request, vnf_id):
-		"""
-		Delete an existig VNF template
-		"""
-		if API.deleteVNFTemplate(vnf_id):
-			return HttpResponse(status=200)
-		return HttpResponse(status=404)
+    def put(self, request, vnf_id):
+        """
+        Update or create a new VNF template
+        """
+        if request.META['CONTENT_TYPE'] != 'application/json':
+            return HttpResponse(status=415)
+        try:
+            if 'functional-capability' not in request.data.keys():
+                return HttpResponse("Missing functional-capability field", status=400)
+            capability = request.data['functional-capability']
+            template = json.dumps(request.data)
+        except:
+            return HttpResponse(status=400)
+        API.addVNFTemplate(vnf_id, template, capability)
+        return HttpResponse(status=200)
+
+    def delete(self, request, vnf_id):
+        """
+        Delete an existing VNF template
+        """
+        if API.deleteVNFTemplate(vnf_id):
+            return HttpResponse(status=200)
+        return HttpResponse(status=404)
+
+
+class VNFTemplateV2(VNFTemplate):
+    """
+    """
+
+    def put(self, request, vnf_id):
+        """
+        Update an existing VNF template
+        """
+        return super(VNFTemplateV2, self).put(request, vnf_id)
 
 
 class VNFImage(APIView):
-	"""
-	"""
-	
-	def get(self, request, vnf_id):
-		"""
-		Get the disk image of a VNF
-		"""
-		try:
-			(wrapper, fileLen) = imageRepo.getImage(vnf_id)
-			response = HttpResponse(wrapper, content_type='text/plain', status=status.HTTP_200_OK)
-			response['Content-Length'] = fileLen
-			return response
-		except:
-			return Response(status=status.HTTP_404_NOT_FOUND)
-	
-	# def put(self, request, vnf_id):
-	# 	"""
-	# 	Insert/update a disk image for a VNF.
-    #
-	# 	DO NOT use this! A new API that supports upload of large files in chunks was developed.
-    #
-	# 	For further details see the example web client provided within this project.
-	# 	"""
-	# 	try:
-	# 		imageRepo.storeImage(vnf_id, request.data['file'])
-	# 		return HttpResponse(status=200)
-	# 	except:
-	# 		return HttpResponse(status=400)
+    """
+    """
 
-	def delete(self, request, vnf_id):
-		"""
-		Remove a disk image for a VNF
-		"""
-		try:
-			os.remove(os.path.join(imagesDir, vnf_id))
-			return HttpResponse(status=200)
-		except:
-			return HttpResponse(status=400)
+    def get(self, request, vnf_id):
+        """
+        Get the disk image of a VNF
+        """
+        try:
+            (wrapper, fileLen) = imageRepo.getImage(vnf_id)
+            response = HttpResponse(wrapper, content_type='text/plain', status=status.HTTP_200_OK)
+            response['Content-Length'] = fileLen
+            return response
+        except:
+            return Response(status=status.HTTP_404_NOT_FOUND)
+
+    def put(self, request, vnf_id):
+        """
+        Insert/update a disk image for a VNF.
+        """
+        try:
+            imageRepo.storeImage(vnf_id, request.data['file'])
+            return HttpResponse(status=200)
+        except:
+            return HttpResponse(status=400)
+
+    def delete(self, request, vnf_id):
+        """
+        Remove a disk image for a VNF
+        """
+        try:
+            os.remove(os.path.join(imagesDir, vnf_id))
+            return HttpResponse(status=200)
+        except:
+            return HttpResponse(status=400)
+
+
+class VNFImageV2(APIView):
+    """
+    """
+
+    def __init__(self):
+        self.VNFImage = VNFImage()
+
+    def get(self, request, vnf_id):
+        """
+        Get the disk image of a VNF
+        """
+        return self.VNFImage.get(request, vnf_id)
+
+    def delete(self, request, vnf_id):
+        """
+        Remove a disk image for a VNF
+        """
+        return self.VNFImage.delete(request, vnf_id)
 
 
 class NFFGraphs(APIView):
-	"""
-	"""
-	def put(self, request, nf_fgraphs_id):
-		"""
-		Update or create a new Network Functions Forwarding Graph
-		"""
-		if request.META['CONTENT_TYPE'] != 'application/json':
-			return HttpResponse(status=415)
-		try:
-			template = json.dumps(request.data)
-		except:
-			return HttpResponse(status=400)
-		if API.addNF_FGraphs(nf_fgraphs_id, template) == False:
-			return HttpResponse("The given ID is different from the template", status=400)
-		return Response(data=json.loads(template))
+    """
+    """
 
-	def delete(self, request, nf_fgraphs_id):
-		"""
-		Delete an existig Network Functions Forwarding Graph
-		"""
-		if API.deleteNF_FGraphs(nf_fgraphs_id):
-			return HttpResponse(status=200)
-		return HttpResponse(status=404)
+    def put(self, request, nf_fgraphs_id):
+        """
+        Update or create a new Network Functions Forwarding Graph
+        """
+        if request.META['CONTENT_TYPE'] != 'application/json':
+            return HttpResponse(status=415)
+        try:
+            template = json.dumps(request.data)
+        except:
+            return HttpResponse(status=400)
+        if API.addNF_FGraphs(nf_fgraphs_id, template) == False:
+            return HttpResponse("The given ID is different from the template", status=400)
+        return Response(data=json.loads(template))
 
+    def delete(self, request, nf_fgraphs_id):
+        """
+        Delete an existig Network Functions Forwarding Graph
+        """
+        if API.deleteNF_FGraphs(nf_fgraphs_id):
+            return HttpResponse(status=200)
+        return HttpResponse(status=404)
 
-	def get(self, request, nf_fgraphs_id):
-		"""
-		Get the Network Functions Forwarding Graph
-		"""
-		template = API.getNF_FGraphs(nf_fgraphs_id)
-		if template is None:
-			return HttpResponse(status=404)
-		return Response(data=template)
+    def get(self, request, nf_fgraphs_id):
+        """
+        Get the Network Functions Forwarding Graph
+        """
+        template = API.getNF_FGraphs(nf_fgraphs_id)
+        if template is None:
+            return HttpResponse(status=404)
+        return Response(data=template)
 
 
 class NF_FGraphsAll(APIView):
-	"""
-	"""
-	def get(self, request):
-		"""
-		Get the all Network Functions Forwarding Graph
-		"""
-		template = API.getNF_FGraphs()
-		if template is None:
-			return HttpResponse(status=404)
-		return Response(data=template)
+    """
+    """
+
+    def get(self, request):
+        """
+        Get the all Network Functions Forwarding Graph
+        """
+        template = API.getNF_FGraphs()
+        if template is None:
+            return HttpResponse(status=404)
+        return Response(data=template)
+
 
 class NF_FGraphsAll_graphs_names(APIView):
-	"""
-	"""
-	def get(self, request):
-		"""
-		Get the all NFFGs Names and ids
-		"""
-		template = API.getNF_FGraphsAll_graphs_names()
-		if template is None:
-			return HttpResponse(status=404)
-		return Response(data=template)
+    """
+    """
+
+    def get(self, request):
+        """
+        Get the all NFFGs Names and ids
+        """
+        template = API.getNF_FGraphsAll_graphs_names()
+        if template is None:
+            return HttpResponse(status=404)
+        return Response(data=template)
 
 
 class Capability(APIView):
+    def get(self, request, capability):
+        """
+        Get the all VNF with the respectively capability
+        """
+        template = API.getTemplatesFromCapability(capability)
+        if template is None:
+            return HttpResponse(status=404)
+        return Response(data=template)
 
-	def get(self, request, capability):
-		"""
-		Get the all VNF with the respectively capability
-		"""
-		template = API.getTemplatesFromCapability(capability)
-		if template is None:
-			return HttpResponse(status=404)
-		return Response(data=template)
 
 class MyChunkedUploadView(ChunkedUploadView, APIView):
-	"""
-	"""
-	field_name = 'the_file'
-	model = MyChunkedUpload
+    """
+    """
+    field_name = 'the_file'
+    model = MyChunkedUpload
 
-	def post(self, request, *args, **kwargs):
-		"""
-		Insert/update a disk image for a VNF.
+    def get_extra_attrs(self, request):
+        attrs = {}
+        for attr in request.POST.keys():
+            attrs.update({attr: request.POST.get(attr)})
+        return attrs
 
-		Subsequent POST requests with chunks of the image file have to be sent.
+    def post(self, request, *args, **kwargs):
+        """
+        Insert/update a disk image for a VNF.
 
-		For further details see the note about NF Image upload API in the README_developer.
-		"""
-		return ChunkedUploadView.post(self, request, *args, **kwargs)
+        Subsequent POST requests with chunks of the image file have to be sent.
 
-	@method_decorator(csrf_exempt)
-	def dispatch(self, *args, **kwargs):
-		return super(MyChunkedUploadView, self).dispatch(*args, **kwargs)
+        For further details see the note about NF Image upload API in the README_developer.
+        """
+        return super(MyChunkedUploadView, self).post(request, *args, **kwargs)
 
-	def check_permissions(self, request):
-	# Allow non authenticated users to make uploads
-		pass
+    @method_decorator(csrf_exempt)
+    def dispatch(self, *args, **kwargs):
+        return super(MyChunkedUploadView, self).dispatch(*args, **kwargs)
+
+    def check_permissions(self, request):
+        # Allow non authenticated users to make uploads
+        pass
 
 
 class MyChunkedUploadCompleteView(ChunkedUploadCompleteView, APIView):
-	"""
-	"""
-	model = MyChunkedUpload
+    """
+    """
+    model = MyChunkedUpload
 
-	def post(self, request, *args, **kwargs):
-		"""
-		Insert/update a disk image for a VNF.
+    def post(self, request, *args, **kwargs):
+        """
+        Insert/update a disk image for a VNF.
 
-		Final POST request has to be sent when an image upload is completed.
+        Final POST request has to be sent when an image upload is completed.
 
-		For further details see the note about NF Image upload API in the README_developer.
-		"""
-		return ChunkedUploadCompleteView.post(self, request, *args, **kwargs)
+        For further details see the note about NF Image upload API in the README_developer.
+        """
+        return super(MyChunkedUploadCompleteView, self).post(request, *args, **kwargs)
 
-	@method_decorator(csrf_exempt)
-	def dispatch(self, *args, **kwargs):
-		return super(MyChunkedUploadCompleteView, self).dispatch(*args, **kwargs)
+    @method_decorator(csrf_exempt)
+    def dispatch(self, *args, **kwargs):
+        return super(MyChunkedUploadCompleteView, self).dispatch(*args, **kwargs)
 
-	def check_permissions(self, request):
-	# Allow non authenticated users to make uploads
-		pass
+    def check_permissions(self, request):
+        # Allow non authenticated users to make uploads
+        pass
 
-	def on_completion(self, uploaded_file, request):
-	# Do something with the uploaded file
-		imageRepo.storeImage(request.POST['vnf_id'], uploaded_file)
+    def on_completion(self, uploaded_file, request):
+        # Store the uploaded NF image file
+        imageRepo.storeImage(request.POST['vnf_id'], uploaded_file)
+        # Set the NF template to completed (in order to show in the available NFs list)
+        VNF.objects.filter(vnf_id=str(request.POST['vnf_id'])).update(image_upload_complete=True)
 
-	def get_response_data(self, chunked_upload, request):
-		filename = chunked_upload.filename
-		offset = chunked_upload.offset
-		chunked_upload.delete()
-		return {'message': ("You successfully uploaded '%s' (%s bytes)!" % (filename, offset))}
+    def get_response_data(self, chunked_upload, request):
+        filename = chunked_upload.filename
+        offset = chunked_upload.offset
+        vnf_id = chunked_upload.vnf_id
+        # Delete the temp upload both from DB and from disk
+        chunked_upload.delete()
+        return {'message': ("You successfully uploaded '%s' (%s bytes) for VNF with ID: %s" % (filename, offset, vnf_id)),
+                'vnf_id': vnf_id}

--- a/sample-clients/Web/client-angularjs.html
+++ b/sample-clients/Web/client-angularjs.html
@@ -131,7 +131,7 @@
                     },
                     chunkdone: function (e, data) { // Called after uploading each chunk
                         scope.$apply(function () {
-                            if (scope.formData.length < 1) {
+                            if (scope.formData.length < 2) {
                                 scope.formData.push(
                                         {"name": "upload_id", "value": data.result.upload_id}
                                 );
@@ -143,6 +143,11 @@
                         });
                     },
                     submit: function (e, data) { // Called before uploading each chunk
+                        scope.$apply(function () {
+                            scope.formData.push(
+                                    {"name": "vnf_id", "value": scope.vnfId}
+                            );
+                        });
                         data.formData = scope.formData;
                     },
                     done: function (e, data) { // Called when the file has completely uploaded

--- a/sample-clients/Web/client-jquery.html
+++ b/sample-clients/Web/client-jquery.html
@@ -71,7 +71,7 @@
             $('#uploadbtn').data(data).prop("disabled", false);
         },
         chunkdone: function (e, data) { // Called after uploading each chunk
-            if (form_data.length < 1) {
+            if (form_data.length < 2) {
                 form_data.push(
                         {"name": "upload_id", "value": data.result.upload_id}
                 );
@@ -82,6 +82,9 @@
             $("#progress").text(Array(progress).join("=") + "> " + progress + "%");
         },
         submit: function (e, data) { // Called before uploading each chunk
+            form_data.push(
+                    {"name": "vnf_id", "value": vnf_id}
+            )
             data.formData = form_data;
         },
         done: function (e, data) { // Called when the file has completely uploaded


### PR DESCRIPTION
I've created an expanded addVNFTemplate method for V2 APIs. This method generates the NF ID (6 alphanumeric chars string, unique in datastore) and provides it into the body reply to the caller. So now there are two URLs for putting templates. One is for creating a new NF (without vnf_id parameter in the url) and one to update existing NFs (vnf_id parameter required). I've also modded the VNF model adding the boolean field "image_upload_complete". This field is meant to filter out NF templates which have uncompleted or in progress image upload from get requests. Now when the command to delete uncompleted image uploads run it also deletes the related template from datastore's DB.